### PR TITLE
include a version using Dune as build system

### DIFF
--- a/sedlex-menhir-dune/Makefile
+++ b/sedlex-menhir-dune/Makefile
@@ -1,0 +1,9 @@
+.PHONY: all run clean
+all:
+	dune build @all
+
+run:
+	dune exec ./calc.exe
+
+clean:
+	dune clean

--- a/sedlex-menhir-dune/calc.ml
+++ b/sedlex-menhir-dune/calc.ml
@@ -1,0 +1,12 @@
+        (* File calc.ml  *)
+        let _ =
+          try
+            let lexbuf = Sedlexing.Utf8.from_channel stdin in
+            while true do
+              let lexer  = Sedlexing.with_tokenizer Lexer.token lexbuf in
+              let parser = MenhirLib.Convert.Simplified.traditional2revised Parser.main in
+              let result = parser lexer in
+                print_int result; print_newline(); flush stdout
+            done
+          with Lexer.Eof ->
+            exit 0

--- a/sedlex-menhir-dune/dune
+++ b/sedlex-menhir-dune/dune
@@ -1,0 +1,10 @@
+(menhir
+  (modules parser)
+)
+
+(executable
+ (name calc)
+ (preprocess (pps sedlex.ppx))
+ (libraries sedlex menhirLib)
+)
+

--- a/sedlex-menhir-dune/dune-project
+++ b/sedlex-menhir-dune/dune-project
@@ -1,0 +1,2 @@
+(lang dune 2.8)
+(using menhir 2.0)

--- a/sedlex-menhir-dune/lexer.ml
+++ b/sedlex-menhir-dune/lexer.ml
@@ -1,0 +1,22 @@
+ 
+let digit = [%sedlex.regexp? '0'..'9']
+let number = [%sedlex.regexp? Plus digit]
+
+open Parser
+exception Eof
+
+
+let rec token buf =
+  match%sedlex buf with
+  | Plus (Chars " \t") -> token buf
+  | '\n' ->   EOL
+  | number -> INT (int_of_string (Sedlexing.Latin1.lexeme buf))
+  | '+' -> PLUS
+  | '-' -> MINUS
+  | '*' -> TIMES
+  | '/' -> DIV
+  | '(' -> LPAREN
+  | ')' -> RPAREN
+  | eof -> raise Eof
+  | _ -> failwith "Unexpected character"
+

--- a/sedlex-menhir-dune/parser.mly
+++ b/sedlex-menhir-dune/parser.mly
@@ -1,0 +1,22 @@
+/* File parser.mly (unchanged) */
+%token <int> INT
+%token PLUS MINUS TIMES DIV
+%token LPAREN RPAREN
+%token EOL
+%left PLUS MINUS        /* lowest precedence */
+%left TIMES DIV         /* medium precedence */
+%nonassoc UMINUS        /* highest precedence */
+%start main             /* the entry point */
+%type <int> main
+%%
+main:
+    expr EOL                { $1 }
+;
+expr:
+    INT                     { $1 }
+  | LPAREN expr RPAREN      { $2 }
+  | expr PLUS expr          { $1 + $3 }
+  | expr MINUS expr         { $1 - $3 }
+  | expr TIMES expr         { $1 * $3 }
+  | expr DIV expr           { $1 / $3 }
+  | MINUS expr %prec UMINUS { - $2 }


### PR DESCRIPTION
It's not so easy to find ready-made dune files for the sedlex+menhir combination. While looking for it online, I found this repository, which answers this question except for the `dune` part.

This PR adds a copy of the sedlex+menhir example, using dune. Two points:

- Maybe it's not so useful to have two copies of the example, and you could keep just the dune version. But them having a dead-simple build script in your `build.sh` also has value, so I kept it as two separate copies for now.
- I haven't updated the `shell.nix` recipe, so I just removed it from that copy. I think it's nice to have it, but you should probably contribute it (I'm no nix user, unfortunately).